### PR TITLE
Add test for unicode responses from API, and fix the bug that trigger…

### DIFF
--- a/mollie/api/error.py
+++ b/mollie/api/error.py
@@ -1,8 +1,22 @@
+import sys
+
+
 class Error(Exception):
     """Base exception."""
 
     def __init__(self, message):
         Exception.__init__(self, message)
+
+    def __str__(self):
+        """
+        Customize string repesentation in Python 2.
+
+        We can't have string representation containing unicode characters in Python 2.
+        """
+        if sys.version_info.major == 2:
+            return self.message.encode('ascii', errors='ignore')
+        else:
+            return super(Error, self).__str__()
 
 
 class RequestError(Error):

--- a/mollie/api/objects/base.py
+++ b/mollie/api/objects/base.py
@@ -33,5 +33,5 @@ class Base(dict):
         return '{name}s'.format(name=cls.__name__.lower())
 
     @classmethod
-    def get_object_resource(cls, client):
+    def get_resource_class(cls, client):
         raise NotImplementedError

--- a/mollie/api/objects/base.py
+++ b/mollie/api/objects/base.py
@@ -25,7 +25,7 @@ class Base(dict):
         """Return a link by its name."""
         try:
             return self['_links'][name]['href']
-        except KeyError:
+        except (KeyError, TypeError):
             return None
 
     @classmethod

--- a/mollie/api/objects/base.py
+++ b/mollie/api/objects/base.py
@@ -31,3 +31,7 @@ class Base(dict):
     @classmethod
     def get_object_name(cls):
         return '{name}s'.format(name=cls.__name__.lower())
+
+    @classmethod
+    def get_object_resource(cls, client):
+        raise NotImplementedError

--- a/mollie/api/objects/chargeback.py
+++ b/mollie/api/objects/chargeback.py
@@ -2,6 +2,11 @@ from .base import Base
 
 
 class Chargeback(Base):
+    @classmethod
+    def get_resource_class(cls, client):
+        from ..resources.chargebacks import Chargebacks
+        return Chargebacks(client)
+
     @property
     def id(self):
         return self._get_property('id')

--- a/mollie/api/objects/customer.py
+++ b/mollie/api/objects/customer.py
@@ -3,6 +3,11 @@ from .list import List
 
 
 class Customer(Base):
+    @classmethod
+    def get_object_resource(cls, client):
+        from ..resources.customers import Customers
+        return Customers(client)
+
     @property
     def id(self):
         return self._get_property('id')

--- a/mollie/api/objects/customer.py
+++ b/mollie/api/objects/customer.py
@@ -4,7 +4,7 @@ from .list import List
 
 class Customer(Base):
     @classmethod
-    def get_object_resource(cls, client):
+    def get_resource_class(cls, client):
         from ..resources.customers import Customers
         return Customers(client)
 

--- a/mollie/api/objects/list.py
+++ b/mollie/api/objects/list.py
@@ -39,3 +39,23 @@ class List(Base):
         if 'count' not in self:
             return None
         return int(self['count'])
+
+    def has_next(self):
+        return self._get_link('next') is not None
+
+    def has_previous(self):
+        return self._get_link('previous') is not None
+
+    def get_next(self):
+        """Return the next set of objects in a list"""
+        url = self._get_link('next')
+        resource = self.object_type.get_object_resource(self.client)
+        resp = resource.perform_api_call(resource.REST_READ, url)
+        return List(resp, self.object_type, client=self.client)
+
+    def get_previous(self):
+        """Return the previous set of objects in a list"""
+        url = self._get_link('previous')
+        resource = self.object_type.get_object_resource(self.client)
+        resp = resource.perform_api_call(resource.REST_READ, url)
+        return List(resp, self.object_type, client=self.client)

--- a/mollie/api/objects/list.py
+++ b/mollie/api/objects/list.py
@@ -41,21 +41,23 @@ class List(Base):
         return int(self['count'])
 
     def has_next(self):
+        """Return True if the list contains an url for the next set"""
         return self._get_link('next') is not None
 
     def has_previous(self):
+        """Return True if the list contains an url for the previous set"""
         return self._get_link('previous') is not None
 
     def get_next(self):
         """Return the next set of objects in a list"""
         url = self._get_link('next')
-        resource = self.object_type.get_object_resource(self.client)
+        resource = self.object_type.get_resource_class(self.client)
         resp = resource.perform_api_call(resource.REST_READ, url)
         return List(resp, self.object_type, client=self.client)
 
     def get_previous(self):
         """Return the previous set of objects in a list"""
         url = self._get_link('previous')
-        resource = self.object_type.get_object_resource(self.client)
+        resource = self.object_type.get_resource_class(self.client)
         resp = resource.perform_api_call(resource.REST_READ, url)
         return List(resp, self.object_type, client=self.client)

--- a/mollie/api/objects/mandate.py
+++ b/mollie/api/objects/mandate.py
@@ -2,6 +2,11 @@ from .base import Base
 
 
 class Mandate(Base):
+    @classmethod
+    def get_resource_class(cls, client):
+        from ..resources.customer_mandates import CustomerMandates
+        return CustomerMandates(client)
+
     STATUS_PENDING = 'pending'
     STATUS_VALID = 'valid'
     STATUS_INVALID = 'invalid'

--- a/mollie/api/objects/method.py
+++ b/mollie/api/objects/method.py
@@ -4,6 +4,11 @@ from .list import List
 
 
 class Method(Base):
+    @classmethod
+    def get_resource_class(cls, client):
+        from ..resources.methods import Methods
+        return Methods(client)
+
     IDEAL = 'ideal'
     CREDITCARD = 'creditcard'
     MISTERCASH = 'mistercash'

--- a/mollie/api/objects/order.py
+++ b/mollie/api/objects/order.py
@@ -6,6 +6,11 @@ from .order_line import OrderLine
 
 
 class Order(Base):
+    @classmethod
+    def get_resource_class(cls, client):
+        from ..resources.orders import Orders
+        return Orders(client)
+
     STATUS_CREATED = 'created'
     STATUS_PAID = 'paid'
     STATUS_AUTHORIZED = 'authorized'

--- a/mollie/api/objects/order.py
+++ b/mollie/api/objects/order.py
@@ -1,4 +1,5 @@
 from ..resources.order_refunds import OrderRefunds
+from ..resources.shipments import Shipments
 from .base import Base
 from .list import List
 from .order_line import OrderLine
@@ -14,6 +15,10 @@ class Order(Base):
     STATUS_SHIPPING = 'shipping'
     STATUS_COMPLETED = 'completed'
     STATUS_EXPIRED = 'expired'
+
+    @property
+    def resource(self):
+        return self._get_property('resource')
 
     @property
     def id(self):
@@ -162,3 +167,20 @@ class Order(Base):
             'count': len(lines),
         }
         return List(result, OrderLine, client=self.client)
+
+    @property
+    def shipments(self):
+        """Retrieve all shipments for an order."""
+        return Shipments(self.client).on(self).list()
+
+    def create_shipment(self, data):
+        """Create a shipments for an order."""
+        return Shipments(self.client).on(self).create(data)
+
+    def get_shipment(self, resource_id):
+        """Retrieve a single shipment by a shipment's ID."""
+        return Shipments(self.client).on(self).get(resource_id)
+
+    def update_shipment(self, resource_id, data):
+        """Update the tracking information of a shipment."""
+        return Shipments(self.client).on(self).update(resource_id, data)

--- a/mollie/api/objects/order.py
+++ b/mollie/api/objects/order.py
@@ -173,7 +173,7 @@ class Order(Base):
         return Shipments(self.client).on(self).list()
 
     def create_shipment(self, data=None):
-        """Create a shipments for an order."""
+        """Create a shipment for an order."""
         if data is None:
             data = {'lines': []}
         return Shipments(self.client).on(self).create(data)

--- a/mollie/api/objects/order.py
+++ b/mollie/api/objects/order.py
@@ -6,7 +6,6 @@ from .order_line import OrderLine
 
 
 class Order(Base):
-
     STATUS_CREATED = 'created'
     STATUS_PAID = 'paid'
     STATUS_AUTHORIZED = 'authorized'
@@ -173,8 +172,10 @@ class Order(Base):
         """Retrieve all shipments for an order."""
         return Shipments(self.client).on(self).list()
 
-    def create_shipment(self, data):
+    def create_shipment(self, data=None):
         """Create a shipments for an order."""
+        if data is None:
+            data = {'lines': []}
         return Shipments(self.client).on(self).create(data)
 
     def get_shipment(self, resource_id):

--- a/mollie/api/objects/order_line.py
+++ b/mollie/api/objects/order_line.py
@@ -2,6 +2,10 @@ from .base import Base
 
 
 class OrderLine(Base):
+    @classmethod
+    def get_resource_class(cls, client):
+        from ..resources.order_lines import OrderLines
+        return OrderLines(client)
 
     STATUS_CREATED = 'created'
     STATUS_AUTHORIZED = 'authorized'

--- a/mollie/api/objects/payment.py
+++ b/mollie/api/objects/payment.py
@@ -3,6 +3,11 @@ from .list import List
 
 
 class Payment(Base):
+    @classmethod
+    def get_resource_class(cls, client):
+        from ..resources.payments import Payments
+        return Payments(client)
+
     STATUS_OPEN = 'open'
     STATUS_PENDING = 'pending'
     STATUS_CANCELED = 'canceled'

--- a/mollie/api/objects/refund.py
+++ b/mollie/api/objects/refund.py
@@ -4,6 +4,11 @@ from .order_line import OrderLine
 
 
 class Refund(Base):
+    @classmethod
+    def get_resource_class(cls, client):
+        from ..resources.refunds import Refunds
+        return Refunds(client)
+
     STATUS_QUEUED = 'queued'
     STATUS_PENDING = 'pending'
     STATUS_PROCESSING = 'processing'

--- a/mollie/api/objects/shipment.py
+++ b/mollie/api/objects/shipment.py
@@ -4,14 +4,6 @@ from .order_line import OrderLine
 
 
 class Shipment(Base):
-    def __init__(self, data, resource=None, client=None):
-        """
-        Override the super __init__ to assign the Client to the result object, which is more flexible since it's
-        not tied to a single API resource type
-        """
-        super(Shipment, self).__init__(data, resource)
-        self.client = client
-
     @property
     def resource(self):
         return self._get_property('resource')

--- a/mollie/api/objects/shipment.py
+++ b/mollie/api/objects/shipment.py
@@ -1,0 +1,62 @@
+from .base import Base
+from .list import List
+from .order_line import OrderLine
+from .order import Order
+
+
+class Shipment(Base):
+    def __init__(self, data, resource=None, client=None):
+        """
+        Override the super __init__ to assign the Client to the result object, which is more flexible since it's
+        not tied to a single API resource type
+        """
+        super(Shipment, self).__init__(data, resource)
+        self.client = client
+
+    @property
+    def resource(self):
+        return self._get_property('resource')
+
+    @property
+    def id(self):
+        return self._get_property('id')
+
+    @property
+    def order_id(self):
+        return self._get_property('orderId')
+
+    @property
+    def created_at(self):
+        return self._get_property('createdAt')
+
+    @property
+    def tracking(self):
+        return self._get_property('tracking')
+
+    @property
+    def lines(self):
+        lines = self._get_property('lines') or []
+        result = {
+            '_embedded': {
+                'lines': lines,
+            },
+            'count': len(lines),
+        }
+        return List(result, OrderLine, client=self.client)
+
+    @property
+    def order(self):
+        """Return the order of this shipment."""
+        url = self._get_link('order')
+        if url:
+            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
+            return Order(resp)
+
+    def has_tracking(self):
+        return self.tracking is not None
+
+    def has_tracking_url(self):
+        return self.has_tracking() and self.tracking['url'] is not None
+
+    def tracking_url(self):
+        return self._get_property('tracking', 'url')

--- a/mollie/api/objects/shipment.py
+++ b/mollie/api/objects/shipment.py
@@ -24,12 +24,6 @@ class Shipment(Base):
     def tracking(self):
         return self._get_property('tracking')
 
-    def has_tracking(self):
-        return self.tracking is not None
-
-    def has_tracking_url(self):
-        return self.has_tracking() and self.tracking['url'] is not None
-
     @property
     def tracking_url(self):
         return self.tracking['url'] if self.has_tracking_url() else None
@@ -49,8 +43,12 @@ class Shipment(Base):
     @property
     def order(self):
         """Return the order of this shipment."""
-        from .order import Order
-        url = self._get_link('order')
-        if url:
-            resp = self._resource.perform_api_call(self._resource.REST_READ, url)
-            return Order(resp)
+        return self.client.orders.get(self.order_id)
+
+    # additional methods
+
+    def has_tracking(self):
+        return self.tracking is not None
+
+    def has_tracking_url(self):
+        return self.has_tracking() and self.tracking['url'] is not None

--- a/mollie/api/objects/shipment.py
+++ b/mollie/api/objects/shipment.py
@@ -1,7 +1,6 @@
 from .base import Base
 from .list import List
 from .order_line import OrderLine
-from .order import Order
 
 
 class Shipment(Base):
@@ -33,8 +32,19 @@ class Shipment(Base):
     def tracking(self):
         return self._get_property('tracking')
 
+    def has_tracking(self):
+        return self.tracking is not None
+
+    def has_tracking_url(self):
+        return self.has_tracking() and self.tracking['url'] is not None
+
+    @property
+    def tracking_url(self):
+        return self.tracking['url'] if self.has_tracking_url() else None
+
     @property
     def lines(self):
+        """Return the order lines of this shipment."""
         lines = self._get_property('lines') or []
         result = {
             '_embedded': {
@@ -47,16 +57,8 @@ class Shipment(Base):
     @property
     def order(self):
         """Return the order of this shipment."""
+        from .order import Order
         url = self._get_link('order')
         if url:
             resp = self._resource.perform_api_call(self._resource.REST_READ, url)
             return Order(resp)
-
-    def has_tracking(self):
-        return self.tracking is not None
-
-    def has_tracking_url(self):
-        return self.has_tracking() and self.tracking['url'] is not None
-
-    def tracking_url(self):
-        return self._get_property('tracking', 'url')

--- a/mollie/api/objects/subscription.py
+++ b/mollie/api/objects/subscription.py
@@ -3,6 +3,11 @@ from .customer import Customer
 
 
 class Subscription(Base):
+    @classmethod
+    def get_resource_class(cls, client):
+        from ..resources.customer_subscriptions import CustomerSubscriptions
+        return CustomerSubscriptions(client)
+
     STATUS_ACTIVE = 'active'
     STATUS_PENDING = 'pending'   # Waiting for a valid mandate.
     STATUS_CANCELED = 'canceled'

--- a/mollie/api/resources/base.py
+++ b/mollie/api/resources/base.py
@@ -72,6 +72,8 @@ class Base(object):
 
     def perform_api_call(self, http_method, path, data=None, params=None):
         resp = self.client.perform_http_call(http_method, path, data, params)
+        # Mollie returns unicode data in responses, but doesn't set the Content-Type header correctly
+        resp.encoding = 'utf-8'
         try:
             result = resp.json() if resp.status_code != 204 else {}
         except Exception:

--- a/mollie/api/resources/base.py
+++ b/mollie/api/resources/base.py
@@ -72,8 +72,9 @@ class Base(object):
 
     def perform_api_call(self, http_method, path, data=None, params=None):
         resp = self.client.perform_http_call(http_method, path, data, params)
-        # Mollie returns unicode data in responses, but doesn't set the Content-Type header correctly
-        resp.encoding = 'utf-8'
+        if 'application/hal+json' in resp.headers.get('Content-Type', ''):
+            # set the content type according to the media type definition
+            resp.encoding = 'utf-8'
         try:
             result = resp.json() if resp.status_code != 204 else {}
         except Exception:

--- a/mollie/api/resources/base.py
+++ b/mollie/api/resources/base.py
@@ -43,7 +43,7 @@ class Base(object):
     def rest_list(self, params=None):
         path = self.get_resource_name()
         result = self.perform_api_call(self.REST_LIST, path, params=params)
-        return List(result, self.get_resource_object({}).__class__)
+        return List(result, self.get_resource_object({}).__class__, client=self.client)
 
     def create(self, data=None, **params):
         if data is not None:

--- a/mollie/api/resources/shipments.py
+++ b/mollie/api/resources/shipments.py
@@ -1,0 +1,19 @@
+from ..objects.shipment import Shipment
+from .base import Base
+
+
+class Shipments(Base):
+    order_id = None
+
+    def get_resource_object(self, result):
+        return Shipment(result, self)
+
+    def get_resource_name(self):
+        return 'orders/{id}/shipments'.format(id=self.order_id)
+
+    def with_parent_id(self, order_id):
+        self.order_id = order_id
+        return self
+
+    def on(self, order):
+        return self.with_parent_id(order.id)

--- a/mollie/api/resources/shipments.py
+++ b/mollie/api/resources/shipments.py
@@ -6,7 +6,7 @@ class Shipments(Base):
     order_id = None
 
     def get_resource_object(self, result):
-        return Shipment(result, self)
+        return Shipment(result, client=self.client)
 
     def get_resource_name(self):
         return 'orders/{id}/shipments'.format(id=self.order_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,22 +22,22 @@ class ImprovedRequestsMock(responses.RequestsMock):
     def get(self, url, filename, status=200):
         """Setup a mock response for a GET request."""
         body = self._get_body(filename)
-        self.add(responses.GET, url, body=body, status=status)
+        self.add(responses.GET, url, body=body, status=status, content_type='application/hal+json')
 
     def post(self, url, filename, status=200):
         """Setup a mock response for a POST request."""
         body = self._get_body(filename)
-        self.add(responses.POST, url, body=body, status=status)
+        self.add(responses.POST, url, body=body, status=status, content_type='application/hal+json')
 
     def delete(self, url, filename, status=204):
         """Setup a mock response for a DELETE request."""
         body = self._get_body(filename)
-        self.add(responses.DELETE, url, body=body, status=status)
+        self.add(responses.DELETE, url, body=body, status=status, content_type='application/hal+json')
 
     def patch(self, url, filename, status=200):
         """Setup a mock response for a PATCH request."""
         body = self._get_body(filename)
-        self.add(responses.PATCH, url, body=body, status=status)
+        self.add(responses.PATCH, url, body=body, status=status, content_type='application/hal+json')
 
     def _get_body(self, filename):
         """Read the response fixture file and return it."""

--- a/tests/responses/order_error.json
+++ b/tests/responses/order_error.json
@@ -1,0 +1,12 @@
+{
+  "status": 422,
+  "title": "Unprocessable Entity",
+  "detail": "Order line 1 is invalid. VAT amount is off. Expected VAT amount to be €3.47 (21.00% over €20.00), got €3.10",
+  "field": "lines.1.vatAmount",
+  "_links": {
+    "documentation": {
+      "href": "https://docs.mollie.com/guides/handling-errors",
+      "type": "text/html"
+    }
+  }
+}

--- a/tests/responses/shipment_single.json
+++ b/tests/responses/shipment_single.json
@@ -1,0 +1,83 @@
+{
+  "resource": "shipment",
+  "id": "shp_3wmsgCJN4U",
+  "orderId": "ord_kEn1PlbGa",
+  "createdAt": "2018-08-09T14:33:54+00:00",
+  "tracking": {
+    "carrier": "PostNL",
+    "code": "3SKABA000000000",
+    "url": "http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1016EE&D=NL&T=C"
+  },
+  "lines": [
+    {
+      "resource": "orderline",
+      "id": "odl_dgtxyl",
+      "orderId": "ord_pbjz8x",
+      "name": "LEGO 42083 Bugatti Chiron",
+      "productUrl": "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
+      "imageUrl": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$",
+      "sku": "5702016116977",
+      "type": "physical",
+      "status": "shipping",
+      "quantity": 2,
+      "unitPrice": {
+        "value": "399.00",
+        "currency": "EUR"
+      },
+      "vatRate": "21.00",
+      "vatAmount": {
+        "value": "121.14",
+        "currency": "EUR"
+      },
+      "discountAmount": {
+        "value": "100.00",
+        "currency": "EUR"
+      },
+      "totalAmount": {
+        "value": "698.00",
+        "currency": "EUR"
+      },
+      "createdAt": "2018-08-02T09:29:56+00:00"
+    },
+    {
+      "resource": "orderline",
+      "id": "odl_dgtxyb",
+      "orderId": "ord_kEn1PlbGa",
+      "name": "LEGO 42056 Porsche 911 GT3 RS",
+      "productUrl": "https://shop.lego.com/nl-NL/Porsche-911-GT3-RS-42056",
+      "imageUrl": "https://sh-s7-live-s.legocdn.com/is/image/LEGO/42056?$PDPDefault$",
+      "sku": "5702015594028",
+      "type": "physical",
+      "status": "shipping",
+      "quantity": 1,
+      "unitPrice": {
+        "value": "329.99",
+        "currency": "EUR"
+      },
+      "vatRate": "21.00",
+      "vatAmount": {
+        "value": "57.27",
+        "currency": "EUR"
+      },
+      "totalAmount": {
+        "value": "329.99",
+        "currency": "EUR"
+      },
+      "createdAt": "2018-08-02T09:29:56+00:00"
+    }
+  ],
+  "_links": {
+    "self": {
+      "href": "https://api.mollie.com/v2/order/ord_kEn1PlbGa/shipments/shp_3wmsgCJN4U",
+      "type": "application/hal+json"
+    },
+    "order": {
+      "href": "https://api.mollie.com/v2/orders/ord_kEn1PlbGa",
+      "type": "application/hal+json"
+    },
+    "documentation": {
+      "href": "https://docs.mollie.com/reference/v2/shipments-api/get-shipment",
+      "type": "text/html"
+    }
+  }
+}

--- a/tests/responses/shipments_list.json
+++ b/tests/responses/shipments_list.json
@@ -1,0 +1,131 @@
+{
+  "count": 2,
+  "_embedded": {
+    "shipments": [
+      {
+        "resource": "shipment",
+        "id": "shp_3wmsgCJN4U",
+        "orderId": "ord_kEn1PlbGa",
+        "createdAt": "2018-08-09T14:33:54+00:00",
+        "tracking": {
+          "carrier": "PostNL",
+          "code": "3SKABA000000000",
+          "url": "http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1016EE&D=NL&T=C"
+        },
+        "lines": [
+          {
+            "resource": "orderline",
+            "id": "odl_dgtxyl",
+            "orderId": "ord_pbjz8x",
+            "name": "LEGO 42083 Bugatti Chiron",
+            "productUrl": "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
+            "imageUrl": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$",
+            "sku": "5702016116977",
+            "type": "physical",
+            "status": "shipping",
+            "quantity": 2,
+            "unitPrice": {
+              "value": "399.00",
+              "currency": "EUR"
+            },
+            "vatRate": "21.00",
+            "vatAmount": {
+              "value": "121.14",
+              "currency": "EUR"
+            },
+            "discountAmount": {
+              "value": "100.00",
+              "currency": "EUR"
+            },
+            "totalAmount": {
+              "value": "698.00",
+              "currency": "EUR"
+            },
+            "createdAt": "2018-08-02T09:29:56+00:00"
+          }
+        ],
+        "_links": {
+          "self": {
+            "href": "https://api.mollie.com/v2/order/ord_kEn1PlbGa/shipments/shp_3wmsgCJN4U",
+            "type": "application/hal+json"
+          },
+          "order": {
+            "href": "https://api.mollie.com/v2/orders/ord_kEn1PlbGa",
+            "type": "application/hal+json"
+          },
+          "documentation": {
+            "href": "https://docs.mollie.com/reference/v2/shipments-api/get-shipment",
+            "type": "text/html"
+          }
+        }
+      },
+      {
+        "resource": "shipment",
+        "id": "shp_3wmsgCJN4v",
+        "orderId": "ord_kEn1PlbGa",
+        "createdAt": "2018-08-09T14:33:55+00:00",
+        "tracking": {
+          "carrier": "PostNL",
+          "code": "3SKABA000000000",
+          "url": "http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1016EE&D=NL&T=C"
+        },
+        "lines": [
+          {
+            "resource": "orderline",
+            "id": "odl_dgtxyl",
+            "orderId": "ord_pbjz8x",
+            "name": "LEGO 42083 Bugatti Chiron",
+            "productUrl": "https://shop.lego.com/nl-NL/Bugatti-Chiron-42083",
+            "imageUrl": "https://sh-s7-live-s.legocdn.com/is/image//LEGO/42083_alt1?$main$",
+            "sku": "5702016116977",
+            "type": "physical",
+            "status": "shipping",
+            "quantity": 2,
+            "unitPrice": {
+              "value": "399.00",
+              "currency": "EUR"
+            },
+            "vatRate": "21.00",
+            "vatAmount": {
+              "value": "121.14",
+              "currency": "EUR"
+            },
+            "discountAmount": {
+              "value": "100.00",
+              "currency": "EUR"
+            },
+            "totalAmount": {
+              "value": "698.00",
+              "currency": "EUR"
+            },
+            "createdAt": "2018-08-02T09:29:56+00:00"
+          }
+        ],
+        "_links": {
+          "self": {
+            "href": "https://api.mollie.com/v2/order/ord_kEn1PlbGa/shipments/shp_3wmsgCJN4v",
+            "type": "application/hal+json"
+          },
+          "order": {
+            "href": "https://api.mollie.com/v2/orders/ord_kEn1PlbGa",
+            "type": "application/hal+json"
+          },
+          "documentation": {
+            "href": "https://docs.mollie.com/reference/v2/shipments-api/get-shipment",
+            "type": "text/html"
+          }
+        }
+      }
+    ]
+  },
+  "_links": {
+    "self": {
+      "href": "https://api.mollie.com/v2/order/ord_kEn1PlbGa/shipments",
+      "type": "application/hal+json"
+    },
+    "documentation": {
+      "href": "https://docs.mollie.com/reference/v2/shipments-api/list-shipments",
+      "type": "text/html"
+    }
+  }
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -208,3 +208,16 @@ def test_client_error_including_field_response(client, response):
         client.payments.create(**params)
     assert excinfo.match('The amount is higher than the maximum')
     assert excinfo.value.field == 'amount'
+
+
+def test_client_unicode_error(client, response):
+    """An error response containing Unicode characters should also be processed correctly."""
+    response.post('https://api.mollie.com/v2/orders', 'order_error', status=422)
+    with pytest.raises(UnprocessableEntityError) as err:
+        # actual POST data for creating an order can be found in test_orders.py
+        client.orders.create({})
+
+    # printing the result should work even when utf-8 characters are in the response.
+    expected = "UnprocessableEntityError('Order line 1 is invalid. VAT amount is off. Expected VAT amount " \
+               "to be €3.47 (21.00% over €20.00), got €3.10',)"
+    assert repr(err.value) == expected

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import sys
 from datetime import datetime
 
 import pkg_resources
@@ -211,14 +214,31 @@ def test_client_error_including_field_response(client, response):
     assert excinfo.value.field == 'amount'
 
 
-def test_client_unicode_error(client, response):
+@pytest.mark.skipif(sys.version_info.major != 2, reason='output differs for python 2')
+def test_client_unicode_error_py2(client, response):
     """An error response containing Unicode characters should also be processed correctly."""
     response.post('https://api.mollie.com/v2/orders', 'order_error', status=422)
     with pytest.raises(UnprocessableEntityError) as err:
         # actual POST data for creating an order can be found in test_orders.py
         client.orders.create({})
 
-    # printing the result should work even when utf-8 characters are in the response.
-    expected = "UnprocessableEntityError('Order line 1 is invalid. VAT amount is off. Expected VAT amount " \
-               "to be €3.47 (21.00% over €20.00), got €3.10',)"
-    assert repr(err.value) == expected
+    # handling the error should work even when utf-8 characters are in the response.
+    exception = err.value
+    expected = 'Order line 1 is invalid. VAT amount is off. ' \
+        'Expected VAT amount to be 3.47 (21.00% over 20.00), got 3.10'
+    assert str(exception) == expected
+
+
+@pytest.mark.skipif(sys.version_info.major == 2, reason='output differs for python 2')
+def test_client_unicode_error_py3(client, response):
+    """An error response containing Unicode characters should also be processed correctly."""
+    response.post('https://api.mollie.com/v2/orders', 'order_error', status=422)
+    with pytest.raises(UnprocessableEntityError) as err:
+        # actual POST data for creating an order can be found in test_orders.py
+        client.orders.create({})
+
+    # handling the error should work even when utf-8 characters are in the response.
+    exception = err.value
+    expected = 'Order line 1 is invalid. VAT amount is off. ' \
+        'Expected VAT amount to be €3.47 (21.00% over €20.00), got €3.10'
+    assert str(exception) == expected

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from datetime import datetime
 
 import pkg_resources

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -81,17 +81,20 @@ def test_list_multiple_api_calls(client, response):
 
     customers = client.customers.list(limit=5)
     assert customers.count == 5
-    all_customers_count = customers.count
-    first_customer = next(customers).id
+    forward_first_id = next(customers).id
+    customer_ids = [customer.id for customer in customers]
     while customers.has_next():
         customers = customers.get_next()
-        all_customers_count += customers.count
+        for customer in customers:
+            customer_ids.append(customer.id)
 
-    assert all_customers_count == 17
+    assert len(customer_ids) == 17, 'Unexpected number of customers'
+    assert len(set(customer_ids)) == 17, 'Unexpected number of unique customers'
 
     # now reverse the behaviour
     while customers.has_previous():
         customers = customers.get_previous()
-        all_customers_count -= customers.count
+    reverse_last_id = next(customers).id
 
-    assert next(customers).id == first_customer
+    assert forward_first_id == reverse_last_id, \
+        "Expected the first customer of the first page to be stable, but it wasn't"

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,5 +1,3 @@
-import pytest
-
 from mollie.api.objects.list import List
 from mollie.api.objects.method import Method
 
@@ -71,15 +69,8 @@ def test_list_multiple_iterations(client, response):
     assert items_fourth_run == methods.count
 
 
-@pytest.mark.xfail(strict=True, reason="Pagination interface is still undecided")
 def test_list_multiple_api_calls(client, response):
-    """
-    Verify that we can iterate over a paginated result set.
-
-    The interface using get_next()/get_previous() is not optimal due to the fact that we cant't
-    retrieve the complete dataset count from the api. When that would be possible, we could implement
-    the List object to handle the next and previous links transparently when iterating over results.
-    """
+    """Verify that we can iterate over a paginated result set."""
     response.get('https://api.mollie.com/v2/customers?limit=5', 'customers_list_first')
     response.get('https://api.mollie.com/v2/customers?from=cst_8pknKQJzJa&limit=5', 'customers_list_second')
     response.get('https://api.mollie.com/v2/customers?from=cst_prs8JjDf57&limit=5', 'customers_list_third')
@@ -91,6 +82,7 @@ def test_list_multiple_api_calls(client, response):
     customers = client.customers.list(limit=5)
     assert customers.count == 5
     all_customers_count = customers.count
+    first_customer = next(customers).id
     while customers.has_next():
         customers = customers.get_next()
         all_customers_count += customers.count
@@ -102,4 +94,4 @@ def test_list_multiple_api_calls(client, response):
         customers = customers.get_previous()
         all_customers_count -= customers.count
 
-    assert all_customers_count == 5
+    assert next(customers).id == first_customer

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -10,6 +10,8 @@ ORDER_ID = 'ord_kEn1PlbGa'
 def test_get_order(client, response):
     """Retrieve a single order by order ID."""
     response.get('https://api.mollie.com/v2/orders/{order_id}'.format(order_id=ORDER_ID), 'order_single')
+    response.get('https://api.mollie.com/v2/orders/{order_id}/shipments'.format(order_id=ORDER_ID), 'shipments_list')
+    response.get('https://api.mollie.com/v2/orders/{order_id}/refunds'.format(order_id=ORDER_ID), 'refunds_list')
 
     order = client.orders.get(ORDER_ID)
     assert isinstance(order, Order)
@@ -54,6 +56,8 @@ def test_get_order(client, response):
     assert order.canceled_at is None
     assert order.completed_at is None
     assert order.checkout_url == 'https://www.mollie.com/payscreen/order/checkout/pbjz8x'
+    assert_list_object(order.shipments, Shipment)
+    assert_list_object(order.refunds, Refund)
 
     assert order.is_created() is True
     assert order.is_paid() is False
@@ -196,23 +200,3 @@ def test_cancel_order(client, response):
     assert isinstance(canceled_order, Order)
     assert canceled_order.is_canceled() is True
     assert canceled_order.is_cancelable is False
-
-
-def test_list_order_refund(client, response):
-    """Retrieve a list of order refunds."""
-    response.get('https://api.mollie.com/v2/orders/{order_id}'.format(order_id=ORDER_ID), 'order_single')
-    response.get('https://api.mollie.com/v2/orders/{order_id}/refunds'.format(order_id=ORDER_ID), 'refunds_list')
-
-    order = client.orders.get(ORDER_ID)
-    refunds = order.refunds
-    assert_list_object(refunds, Refund)
-
-
-def test_list_shipments(client, response):
-    """Retrieve all shipments for an order."""
-    response.get('https://api.mollie.com/v2/orders/{order_id}'.format(order_id=ORDER_ID), 'order_single')
-    response.get('https://api.mollie.com/v2/orders/{order_id}/shipments'.format(order_id=ORDER_ID), 'shipments_list')
-
-    order = client.orders.get(ORDER_ID)
-    shipments = order.shipments
-    assert_list_object(shipments, Shipment)

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,5 +1,6 @@
 from mollie.api.objects.order import Order
 from mollie.api.objects.refund import Refund
+from mollie.api.objects.shipment import Shipment
 
 from .utils import assert_list_object
 
@@ -205,3 +206,13 @@ def test_list_order_refund(client, response):
     order = client.orders.get(ORDER_ID)
     refunds = order.refunds
     assert_list_object(refunds, Refund)
+
+
+def test_list_shipments(client, response):
+    """Retrieve all shipments for an order."""
+    response.get('https://api.mollie.com/v2/orders/{order_id}'.format(order_id=ORDER_ID), 'order_single')
+    response.get('https://api.mollie.com/v2/orders/{order_id}/shipments'.format(order_id=ORDER_ID), 'shipments_list')
+
+    order = client.orders.get(ORDER_ID)
+    shipments = order.shipments
+    assert_list_object(shipments, Shipment)

--- a/tests/test_shipments.py
+++ b/tests/test_shipments.py
@@ -1,0 +1,110 @@
+from mollie.api.objects.order import Order
+from mollie.api.objects.order_line import OrderLine
+from mollie.api.objects.shipment import Shipment
+
+from .utils import assert_list_object
+
+ORDER_ID = 'ord_kEn1PlbGa'
+SHIPMENT_ID = 'shp_3wmsgCJN4U'
+
+
+def test_get_shipment(client, response):
+    """Retrieve a single shipment by a shipment's ID."""
+    response.get('https://api.mollie.com/v2/orders/{order_id}'.format(order_id=ORDER_ID), 'order_single')
+    response.get('https://api.mollie.com/v2/orders/{order_id}/shipments/{shipment_id}'.format(
+        order_id=ORDER_ID, shipment_id=SHIPMENT_ID), 'shipment_single')
+
+    order = client.orders.get(ORDER_ID)
+    shipment = order.get_shipment(SHIPMENT_ID)
+
+    assert isinstance(shipment, Shipment)
+    assert shipment.resource == 'shipment'
+    assert shipment.id == SHIPMENT_ID
+    assert shipment.order_id == ORDER_ID
+    assert shipment.created_at == '2018-08-09T14:33:54+00:00'
+    assert shipment.tracking == {
+        'carrier': 'PostNL',
+        'code': '3SKABA000000000',
+        'url': 'http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1016EE&D=NL&T=C'
+    }
+    assert shipment.has_tracking() is True
+    assert shipment.has_tracking_url() is True
+    assert shipment.tracking_url == 'http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1016EE&D=NL&T=C'
+
+
+def test_get_shipment_lines(client, response):
+    """Retrieve a single shipment and the order lines shipped by a shipment's ID."""
+    response.get('https://api.mollie.com/v2/orders/{order_id}'.format(order_id=ORDER_ID), 'order_single')
+    response.get('https://api.mollie.com/v2/orders/{order_id}/shipments/{shipment_id}'.format(
+        order_id=ORDER_ID, shipment_id=SHIPMENT_ID), 'shipment_single')
+
+    order = client.orders.get(ORDER_ID)
+    shipment = order.get_shipment(SHIPMENT_ID)
+    lines = shipment.lines
+
+    assert_list_object(lines, OrderLine)
+
+
+def test_get_order_from_shipment(client, response):
+    """Retrieve the order from the shipment object"""
+    response.get('https://api.mollie.com/v2/orders/{order_id}'.format(order_id=ORDER_ID), 'order_single')
+    response.get('https://api.mollie.com/v2/orders/{order_id}/shipments/{shipment_id}'.format(
+        order_id=ORDER_ID, shipment_id=SHIPMENT_ID), 'shipment_single')
+    order = client.orders.get(ORDER_ID)
+    shipment = order.get_shipment(SHIPMENT_ID)
+
+    assert isinstance(shipment.order, Order)
+    assert order == shipment.order
+
+
+def test_create_shipment(client, response):
+    """Create a shipment of an order object"""
+    response.get('https://api.mollie.com/v2/orders/{order_id}'.format(order_id=ORDER_ID), 'order_single')
+    response.post('https://api.mollie.com/v2/orders/ord_kEn1PlbGa/shipments', 'shipment_single')
+    data = {
+        'lines': [
+            {
+                'id': 'odl_dgtxyl',
+                'quantity': 1
+            },
+            {
+                'id': 'odl_dgtxyb'
+            }
+        ],
+        'tracking': {
+            'carrier': 'PostNL',
+            'code': '3SKABA000000000',
+            'url': 'http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1016EE&D=NL&T=C'
+        },
+    }
+    order = client.orders.get(ORDER_ID)
+    new_shipment = order.create_shipment(data)
+    assert isinstance(new_shipment, Shipment)
+
+
+def test_update_shipment(client, response):
+    """Update the tracking information of a shipment"""
+    response.get('https://api.mollie.com/v2/orders/{order_id}'.format(order_id=ORDER_ID), 'order_single')
+    response.patch('https://api.mollie.com/v2/orders/{order_id}/shipments/{shipment_id}'.format(
+        order_id=ORDER_ID, shipment_id=SHIPMENT_ID), 'shipment_single')
+
+    order = client.orders.get(ORDER_ID)
+    data = {
+         'tracking': {
+             'carrier': 'PostNL',
+             'code': '3SKABA000000000',
+             'url': 'http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1016EE&D=NL&T=C'
+         },
+     }
+    updated_shipment = order.update_shipment(SHIPMENT_ID, data)
+    assert isinstance(updated_shipment, Shipment)
+    assert updated_shipment.id == SHIPMENT_ID
+
+
+def test_list_shipments(client, response):
+    """Retrieve all shipments for an order."""
+    response.get('https://api.mollie.com/v2/orders/{order_id}'.format(order_id=ORDER_ID), 'order_single')
+    response.get('https://api.mollie.com/v2/orders/{order_id}/shipments'.format(order_id=ORDER_ID), 'shipments_list')
+    order = client.orders.get(ORDER_ID)
+    shipments = order.shipments
+    assert_list_object(shipments, Shipment)

--- a/tests/test_shipments.py
+++ b/tests/test_shipments.py
@@ -16,7 +16,6 @@ def test_get_shipment(client, response):
 
     order = client.orders.get(ORDER_ID)
     shipment = order.get_shipment(SHIPMENT_ID)
-
     assert isinstance(shipment, Shipment)
     assert shipment.resource == 'shipment'
     assert shipment.id == SHIPMENT_ID
@@ -41,7 +40,6 @@ def test_get_shipment_lines(client, response):
     order = client.orders.get(ORDER_ID)
     shipment = order.get_shipment(SHIPMENT_ID)
     lines = shipment.lines
-
     assert_list_object(lines, OrderLine)
 
 
@@ -50,9 +48,9 @@ def test_get_order_from_shipment(client, response):
     response.get('https://api.mollie.com/v2/orders/{order_id}'.format(order_id=ORDER_ID), 'order_single')
     response.get('https://api.mollie.com/v2/orders/{order_id}/shipments/{shipment_id}'.format(
         order_id=ORDER_ID, shipment_id=SHIPMENT_ID), 'shipment_single')
+
     order = client.orders.get(ORDER_ID)
     shipment = order.get_shipment(SHIPMENT_ID)
-
     assert isinstance(shipment.order, Order)
     assert order == shipment.order
 
@@ -61,6 +59,7 @@ def test_create_shipment(client, response):
     """Create a shipment of an order object"""
     response.get('https://api.mollie.com/v2/orders/{order_id}'.format(order_id=ORDER_ID), 'order_single')
     response.post('https://api.mollie.com/v2/orders/ord_kEn1PlbGa/shipments', 'shipment_single')
+
     data = {
         'lines': [
             {
@@ -105,6 +104,7 @@ def test_list_shipments(client, response):
     """Retrieve all shipments for an order."""
     response.get('https://api.mollie.com/v2/orders/{order_id}'.format(order_id=ORDER_ID), 'order_single')
     response.get('https://api.mollie.com/v2/orders/{order_id}/shipments'.format(order_id=ORDER_ID), 'shipments_list')
+
     order = client.orders.get(ORDER_ID)
     shipments = order.shipments
     assert_list_object(shipments, Shipment)

--- a/tests/test_shipments.py
+++ b/tests/test_shipments.py
@@ -29,30 +29,8 @@ def test_get_shipment(client, response):
     assert shipment.has_tracking() is True
     assert shipment.has_tracking_url() is True
     assert shipment.tracking_url == 'http://postnl.nl/tracktrace/?B=3SKABA000000000&P=1016EE&D=NL&T=C'
-
-
-def test_get_shipment_lines(client, response):
-    """Retrieve a single shipment and the order lines shipped by a shipment's ID."""
-    response.get('https://api.mollie.com/v2/orders/{order_id}'.format(order_id=ORDER_ID), 'order_single')
-    response.get('https://api.mollie.com/v2/orders/{order_id}/shipments/{shipment_id}'.format(
-        order_id=ORDER_ID, shipment_id=SHIPMENT_ID), 'shipment_single')
-
-    order = client.orders.get(ORDER_ID)
-    shipment = order.get_shipment(SHIPMENT_ID)
-    lines = shipment.lines
-    assert_list_object(lines, OrderLine)
-
-
-def test_get_order_from_shipment(client, response):
-    """Retrieve the order from the shipment object"""
-    response.get('https://api.mollie.com/v2/orders/{order_id}'.format(order_id=ORDER_ID), 'order_single')
-    response.get('https://api.mollie.com/v2/orders/{order_id}/shipments/{shipment_id}'.format(
-        order_id=ORDER_ID, shipment_id=SHIPMENT_ID), 'shipment_single')
-
-    order = client.orders.get(ORDER_ID)
-    shipment = order.get_shipment(SHIPMENT_ID)
+    assert_list_object(shipment.lines, OrderLine)
     assert isinstance(shipment.order, Order)
-    assert order == shipment.order
 
 
 def test_create_shipment(client, response):
@@ -98,13 +76,3 @@ def test_update_shipment(client, response):
     updated_shipment = order.update_shipment(SHIPMENT_ID, data)
     assert isinstance(updated_shipment, Shipment)
     assert updated_shipment.id == SHIPMENT_ID
-
-
-def test_list_shipments(client, response):
-    """Retrieve all shipments for an order."""
-    response.get('https://api.mollie.com/v2/orders/{order_id}'.format(order_id=ORDER_ID), 'order_single')
-    response.get('https://api.mollie.com/v2/orders/{order_id}/shipments'.format(order_id=ORDER_ID), 'shipments_list')
-
-    order = client.orders.get(ORDER_ID)
-    shipments = order.shipments
-    assert_list_object(shipments, Shipment)


### PR DESCRIPTION
Working around the fact that Mollie sends UTF-8 responses, but doesn't set the HTTP Content-type headers to reflect this (which results in UnicodeDecodeErrors further down the line). Also reported to Mollie.